### PR TITLE
Provide instructions on how to install a specific tagged version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,6 @@ cap noi net uninstall multe
 net install multe, from(`github'/gphk-metrics/stata-multe/main/)
 ```
 
-From Stata, for a specific tagged version (see [Tags](https://github.com/gphk-metrics/stata-multe/tags)):
-
-```stata
-local github "https://raw.githubusercontent.com"
-local multeversion "1.1.0.1"
-cap noi net uninstall multe
-net install multe, from(`github'/gphk-metrics/stata-multe/`mutleversion'/)
-```
-
-
-
 You can also clone or download the code manually, e.g. to
 `stata-multe-main`, and install from a local folder:
 
@@ -37,6 +26,19 @@ You can also clone or download the code manually, e.g. to
 cap noi net uninstall multe
 net install multe, from(`c(pwd)'/stata-multe-main)
 ```
+
+We typically recommend installing the latest version; however, if you need a specific
+tagged version (e.g. for replication purposes):
+
+```stata
+local github "https://raw.githubusercontent.com"
+local multeversion "1.1.0"
+cap noi net uninstall multe
+net install multe, from(`github'/gphk-metrics/stata-multe/`mutleversion'/)
+```
+
+See the [tags](https://github.com/gphk-metrics/stata-multe/tags)) page for all
+available tagged versions.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cap noi net uninstall multe
 net install multe, from(`github'/gphk-metrics/stata-multe/`mutleversion'/)
 ```
 
-See the [tags](https://github.com/gphk-metrics/stata-multe/tags)) page for all
+See the [tags](https://github.com/gphk-metrics/stata-multe/tags) page for all
 available tagged versions.
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -11,13 +11,24 @@ based on R's [multe](https://github.com/kolesarm/multe?tab=readme-ov-file) packa
 
 ### Installation
 
-From Stata
+From Stata, latest version:
 
 ```stata
 local github "https://raw.githubusercontent.com"
 cap noi net uninstall multe
 net install multe, from(`github'/gphk-metrics/stata-multe/main/)
 ```
+
+From Stata, for a specific tagged version (see [Tags](https://github.com/gphk-metrics/stata-multe/tags)):
+
+```stata
+local github "https://raw.githubusercontent.com"
+local multeversion "1.1.0.1"
+cap noi net uninstall multe
+net install multe, from(`github'/gphk-metrics/stata-multe/`mutleversion'/)
+```
+
+
 
 You can also clone or download the code manually, e.g. to
 `stata-multe-main`, and install from a local folder:


### PR DESCRIPTION
@mcaceresb it would be great if you provided tags that correspond to the version number that is embedded. I've updated the README, but you may have to create the tags in your main repository, e.g.

```
git tag 1.1.0 77706f2702c43b63f2b427b6e281b286711a34c4
git push --tags
```

I ran into a problem where a researcher had used an earlier version, and the newer version didn't work with their code. Referencing the older commit worked, but commits are messy...